### PR TITLE
Allow whitelisting classes for `Loader::Yaml#call`.

### DIFF
--- a/lib/front_matter_parser/loader/yaml.rb
+++ b/lib/front_matter_parser/loader/yaml.rb
@@ -6,12 +6,20 @@ module FrontMatterParser
   module Loader
     # {Loader} that uses YAML library
     class Yaml
+      # @!attribute [r] whitelist_classes
+      # Classes that may be parsed by #call.
+      attr_reader :whitelist_classes
+
+      def initialize(whitelist_classes: [])
+        @whitelist_classes = whitelist_classes
+      end
+
       # Loads a hash front matter from a string
       #
       # @param string [String] front matter string representation
       # @return [Hash] front matter hash representation
-      def self.call(string)
-        YAML.safe_load(string)
+      def call(string)
+        YAML.safe_load(string, whitelist_classes)
       end
     end
   end

--- a/lib/front_matter_parser/parser.rb
+++ b/lib/front_matter_parser/parser.rb
@@ -18,8 +18,9 @@ module FrontMatterParser
     # @param syntax_parser [Object] see {SyntaxParser}
     # @param loader [Object] see {Loader}
     # @return [Parsed] parsed front matter and content
-    def self.parse_file(pathname, syntax_parser: nil, loader: Loader::Yaml)
+    def self.parse_file(pathname, syntax_parser: nil, loader: nil)
       syntax_parser ||= syntax_from_pathname(pathname)
+      loader ||= Loader::Yaml.new
       File.open(pathname) do |file|
         new(syntax_parser, loader: loader).call(file.read)
       end
@@ -49,7 +50,7 @@ module FrontMatterParser
     #
     # @param loader [Object] Front matter loader to use. See {Loader} for
     # details.
-    def initialize(syntax_parser, loader: Loader::Yaml)
+    def initialize(syntax_parser, loader: Loader::Yaml.new)
       @syntax_parser = infer_syntax_parser(syntax_parser)
       @loader = loader
     end

--- a/lib/front_matter_parser/syntax_parser/indentation_comment.rb
+++ b/lib/front_matter_parser/syntax_parser/indentation_comment.rb
@@ -43,6 +43,7 @@ module FrontMatterParser
         \z
         /mx
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/front_matter_parser/syntax_parser/multi_line_comment.rb
+++ b/lib/front_matter_parser/syntax_parser/multi_line_comment.rb
@@ -44,6 +44,7 @@ module FrontMatterParser
         \z
         /mx
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/front_matter_parser/syntax_parser/single_line_comment.rb
+++ b/lib/front_matter_parser/syntax_parser/single_line_comment.rb
@@ -58,6 +58,7 @@ module FrontMatterParser
         \z
         /mx
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/spec/front_matter_parser/loader/yaml_spec.rb
+++ b/spec/front_matter_parser/loader/yaml_spec.rb
@@ -3,12 +3,21 @@
 require 'spec_helper'
 
 describe FrontMatterParser::Loader::Yaml do
-  describe '::call' do
+  describe '#call' do
     it 'loads using yaml parser' do
       string = "title: 'hello'"
 
-      expect(described_class.call(string)).to eq(
+      expect(described_class.new.call(string)).to eq(
         'title' => 'hello'
+      )
+    end
+
+    it 'loads with whitelisted classes' do
+      string = 'timestamp: 2017-10-17 00:00:00Z'
+      params = { whitelist_classes: [Time] }
+
+      expect(described_class.new(params).call(string)).to eq(
+        'timestamp' => Time.parse('2017-10-17 00:00:00Z')
       )
     end
   end

--- a/spec/front_matter_parser/parser_spec.rb
+++ b/spec/front_matter_parser/parser_spec.rb
@@ -8,14 +8,14 @@ describe FrontMatterParser::Parser do
 
   describe '#call' do
     let(:string) do
-      <<~eos
+      <<~STRING
         <!--
         ---
         title: hello
         ---
         -->
         Content
-      eos
+      STRING
     end
 
     it 'parses using given parser' do

--- a/spec/front_matter_parser/syntax_parser/indentation_comment_spec.rb
+++ b/spec/front_matter_parser/syntax_parser/indentation_comment_spec.rb
@@ -8,17 +8,17 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
   let(:front_matter) { { 'title' => 'hello', 'author' => 'me' } }
   let(:content) { "Content\n" }
 
-  context 'slim' do
+  context 'when syntax is slim' do
     let(:syntax) { :slim }
     let(:string) do
-      <<~eos
+      <<~STRING
         /
          ---
          title: hello
          author: me
          ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -26,17 +26,17 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
     end
   end
 
-  context 'haml' do
+  context 'when syntax is haml' do
     let(:syntax) { :haml }
     let(:string) do
-      <<~eos
+      <<~STRING
         -#
           ---
           title: hello
           author: me
           ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -47,7 +47,7 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
   context 'with space before comment delimiter' do
     let(:syntax) { :slim }
     let(:string) do
-      <<~eos
+      <<~STRING
 
           /
            ---
@@ -55,7 +55,7 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
            author: me
            ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -66,13 +66,13 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
   context 'with front matter starting in comment delimiter line' do
     let(:syntax) { :slim }
     let(:string) do
-      <<~eos
+      <<~STRING
         /---
          title: hello
          author: me
          ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -83,7 +83,7 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
   context 'with space before front matter' do
     let(:syntax) { :slim }
     let(:string) do
-      <<~eos
+      <<~STRING
         /
 
              ---
@@ -91,7 +91,7 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
           author: me
          ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -102,7 +102,7 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
   context 'with space within front matter' do
     let(:syntax) { :slim }
     let(:string) do
-      <<~eos
+      <<~STRING
         /
           ---
             title: hello
@@ -110,7 +110,7 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
             author: me
           ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -121,14 +121,14 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
   context 'with comment delimiter in the front matter' do
     let(:syntax) { :slim }
     let(:string) do
-      <<~eos
+      <<~STRING
         /
          ---
          title: /hello
          author: me
          ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -141,14 +141,14 @@ describe FrontMatterParser::SyntaxParser::IndentationComment do
   context 'with front matter delimiter chars in the content' do
     let(:syntax) { :slim }
     let(:string) do
-      <<~eos
+      <<~STRING
         /
          ---
          title: hello
          ---
         Content
         ---
-      eos
+      STRING
     end
 
     it 'is not greedy' do

--- a/spec/front_matter_parser/syntax_parser/multi_line_comment_spec.rb
+++ b/spec/front_matter_parser/syntax_parser/multi_line_comment_spec.rb
@@ -8,10 +8,10 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
   let(:front_matter) { { 'title' => 'hello', 'author' => 'me' } }
   let(:content) { "Content\n" }
 
-  context 'html' do
+  context 'when syntax is html' do
     let(:syntax) { :html }
     let(:string) do
-      <<~eos
+      <<~STRING
         <!--
         ---
         title: hello
@@ -19,7 +19,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
         ---
         -->
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -27,10 +27,10 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
     end
   end
 
-  context 'erb' do
+  context 'when syntax is erb' do
     let(:syntax) { :erb }
     let(:string) do
-      <<~eos
+      <<~STRING
         <%#
         ---
         title: hello
@@ -38,7 +38,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
         ---
         %>
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -46,10 +46,10 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
     end
   end
 
-  context 'liquid' do
+  context 'when syntax is liquid' do
     let(:syntax) { :liquid }
     let(:string) do
-      <<~eos
+      <<~STRING
         {% comment %}
         ---
         title: hello
@@ -57,7 +57,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
         ---
         {% endcomment %}
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -65,16 +65,16 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
     end
   end
 
-  context 'md' do
+  context 'when syntax is md' do
     let(:syntax) { :md }
     let(:string) do
-      <<~eos
+      <<~STRING
         ---
         title: hello
         author: me
         ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -85,7 +85,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
   context 'with space before start comment delimiter' do
     let(:syntax) { :html }
     let(:string) do
-      <<~eos
+      <<~STRING
 
            <!--
         ---
@@ -94,7 +94,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
         ---
         -->
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -105,14 +105,14 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
   context 'with front matter starting in comment delimiter line' do
     let(:syntax) { :html }
     let(:string) do
-      <<~eos
+      <<~STRING
         <!-- ---
         title: hello
         author: me
         ---
         -->
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -123,7 +123,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
   context 'with space before front matter' do
     let(:syntax) { :html }
     let(:string) do
-      <<~eos
+      <<~STRING
         <!--
 
            ---
@@ -132,7 +132,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
         ---
         -->
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -143,7 +143,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
   context 'with space within front matter' do
     let(:syntax) { :html }
     let(:string) do
-      <<~eos
+      <<~STRING
         <!--
         ---
           title: hello
@@ -152,7 +152,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
         ---
         -->
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -163,7 +163,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
   context 'with space after front matter' do
     let(:syntax) { :html }
     let(:string) do
-      <<~eos
+      <<~STRING
         <!--
         ---
         title: hello
@@ -172,7 +172,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
 
         -->
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -183,7 +183,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
   context 'with space before end comment delimiter' do
     let(:syntax) { :html }
     let(:string) do
-      <<~eos
+      <<~STRING
         <!--
         ---
         title: hello
@@ -191,7 +191,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
         ---
            -->
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -202,7 +202,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
   context 'with start comment delimiter in the front matter' do
     let(:syntax) { :html }
     let(:string) do
-      <<~eos
+      <<~STRING
         <!--
         ---
         title: <!--hello
@@ -210,7 +210,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
         ---
            -->
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -223,7 +223,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
   context 'with start and end comment delimiter in the front matter' do
     let(:syntax) { :html }
     let(:string) do
-      <<~eos
+      <<~STRING
         <!--
         ---
         title: <!--hello-->
@@ -231,7 +231,7 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
         ---
            -->
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -244,12 +244,12 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
   context 'with front matter delimiter chars in the content' do
     let(:syntax) { :md }
     let(:string) do
-      <<~eos
+      <<~STRING
         ---
         title: hello
         ---
         Content---
-      eos
+      STRING
     end
 
     it 'is not greedy' do

--- a/spec/front_matter_parser/syntax_parser/single_line_comment_spec.rb
+++ b/spec/front_matter_parser/syntax_parser/single_line_comment_spec.rb
@@ -8,16 +8,16 @@ describe FrontMatterParser::SyntaxParser::SingleLineComment do
   let(:front_matter) { { 'title' => 'hello', 'author' => 'me' } }
   let(:content) { "Content\n" }
 
-  context 'coffee' do
+  context 'when syntax is coffee' do
     let(:syntax) { :coffee }
     let(:string) do
-      <<~eos
+      <<~STRING
         #---
         #title: hello
         #author: me
         #---
         Content
-        eos
+      STRING
     end
 
     it 'can parse it' do
@@ -25,16 +25,16 @@ describe FrontMatterParser::SyntaxParser::SingleLineComment do
     end
   end
 
-  context 'sass' do
+  context 'when syntax is sass' do
     let(:syntax) { :sass }
     let(:string) do
-      <<~eos
+      <<~STRING
         //---
         //title: hello
         //author: me
         //---
         Content
-        eos
+      STRING
     end
 
     it 'can parse it' do
@@ -42,16 +42,16 @@ describe FrontMatterParser::SyntaxParser::SingleLineComment do
     end
   end
 
-  context 'scss' do
+  context 'when syntax is scss' do
     let(:syntax) { :scss }
     let(:string) do
-      <<~eos
+      <<~STRING
         //---
         //title: hello
         //author: me
         //---
         Content
-        eos
+      STRING
     end
 
     it 'can parse it' do
@@ -62,13 +62,13 @@ describe FrontMatterParser::SyntaxParser::SingleLineComment do
   context 'with space before comment delimiters' do
     let(:syntax) { :coffee }
     let(:string) do
-      <<~eos
+      <<~STRING
          #---
          #title: hello
          #author: me
          #---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -79,13 +79,13 @@ describe FrontMatterParser::SyntaxParser::SingleLineComment do
   context 'with space between comment delimiters and front matter' do
     let(:syntax) { :coffee }
     let(:string) do
-      <<~eos
+      <<~STRING
         # ---
         # title: hello
         # author: me
         # ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -96,14 +96,14 @@ describe FrontMatterParser::SyntaxParser::SingleLineComment do
   context 'with space within front matter' do
     let(:syntax) { :coffee }
     let(:string) do
-      <<~eos
+      <<~STRING
         # ---
         #   title: hello
         #
         #   author: me
         # ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -114,14 +114,14 @@ describe FrontMatterParser::SyntaxParser::SingleLineComment do
   context 'with uncommented lines between front matter' do
     let(:syntax) { :coffee }
     let(:string) do
-      <<~eos
+      <<~STRING
         # ---
         #   title: hello
 
         #   author: me
         # ---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -132,13 +132,13 @@ describe FrontMatterParser::SyntaxParser::SingleLineComment do
   context 'with comment delimiter in the front matter' do
     let(:syntax) { :sass }
     let(:string) do
-      <<~eos
+      <<~STRING
         //---
         //title: //hello
         //author: me
         //---
         Content
-      eos
+      STRING
     end
 
     it 'can parse it' do
@@ -151,13 +151,13 @@ describe FrontMatterParser::SyntaxParser::SingleLineComment do
   context 'with front matter delimiter chars in the content' do
     let(:syntax) { :sass }
     let(:string) do
-      <<~eos
+      <<~STRING
         //---
         //title: hello
         //---
         //---
         Content
-      eos
+      STRING
     end
 
     it 'is not greedy' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,9 @@ require 'simplecov'
 
 SimpleCov.start
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'front_matter_parser'
 require 'pry-byebug'
-Dir["#{File.expand_path('../support', __FILE__)}/*.rb"].each do |file|
+Dir["#{File.expand_path('support', __dir__)}/*.rb"].each do |file|
   require file
 end


### PR DESCRIPTION
Parsing the following file `example.md` raises a `Psych::DisallowedClass` exception.

```markdown
---
timestamp: 2017-10-17 00:00:00Z
---
# Title
This is a sentence.
```

The reason is that the default loader uses `YAML.safe_load` w/o passing a whitelist of classes for values. When `YAML.safe_load` tries to load the timestamp, it tries to create an instance of `Time` but `Time` is not whitelisted and thus it raises an exception.

This PR fixes the problem by allowing the user to create a loader with a given class whitelist.

```ruby
loader = FrontMatterParser::Loader::Yaml.new(whitelisted_classes: [Time])
parsed = FrontMatterParser::Parser.parse_file('example.md', loader: loader)
puts parsed['timestamp']
```