### PR TITLE
Rename whitelist to allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.0] - 2020-08-31
+- Depreciate "whitelist" in favor of "allowlist" by renaming the `whitelist_classes` param to `allowlist_classes`.
+
+If your project uses the `whitelist_classes` param, you will need to upgrade your code as follows:
+
+```ruby
+## before
+loader = FrontMatterParser::Loader::Yaml.new(whitelist_classes: [Time])
+
+## after
+loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Time])
+```
+
 ## [0.2.1] - 2019-06-06
 ### Fixed
 - Do not add `bin` development executables to generated gem.

--- a/README.md
+++ b/README.md
@@ -75,17 +75,17 @@ title = FrontMatterParser::Parser.parse_file('example.haml')['title'] #=> 'Hello
 
 Following there is a relation of known syntaxes and their known comment delimiters:
 
-| Syntax | Single line comment | Start multiline comment | End multiline comment  |
-| ------ | ------------------- | ----------------------- | ---------------------- |
-| haml   |                     | -#                      | (indentation)          |
-| slim   |                     | /                       | (indentation)          |
-| liquid |                     | {% comment %}           | {% endcomment %}       |
-| md     |                     |                         |                        |
-| html   |                     | &lt;!--                 | --&gt;                 |
-| erb    |                     | &lt;%#                  | %&gt;                  |
-| coffee | #                   |                         |                        |
-| sass   | //                  |                         |                        |
-| scss   | //                  |                         |                        |
+| Syntax | Single line comment | Start multiline comment | End multiline comment |
+| ------ | ------------------- | ----------------------- | --------------------- |
+| haml   |                     | -#                      | (indentation)         |
+| slim   |                     | /                       | (indentation)         |
+| liquid |                     | {% comment %}           | {% endcomment %}      |
+| md     |                     |                         |                       |
+| html   |                     | &lt;!--                 | --&gt;                |
+| erb    |                     | &lt;%#                  | %&gt;                 |
+| coffee | #                   |                         |                       |
+| sass   | //                  |                         |                       |
+| scss   | //                  |                         |                       |
 
 ### Parsing a string
 
@@ -134,10 +134,10 @@ FrontMatterParser::Parser.parse_file('example.md', loader: json_loader)
 FrontMatterParser::Parser.new(:md, loader: json_loader).call(string)
 ```
 
-If you need to whitelist some class for the built-in YAML loader, you can just create a custom loader based on it and provide needed classes in a `whitelist_classes:` param:
+If you need to allow one or more classes for the built-in YAML loader, you can just create a custom loader based on it and provide needed classes in a `allowlist_classes:` param:
 
 ```ruby
-loader = FrontMatterParser::Loader::Yaml.new(whitelist_classes: [Time])
+loader = FrontMatterParser::Loader::Yaml.new(allowlist_classes: [Time])
 parsed = FrontMatterParser::Parser.parse_file('example.md', loader: loader)
 puts parsed['timestamp']
 ```

--- a/lib/front_matter_parser/loader/yaml.rb
+++ b/lib/front_matter_parser/loader/yaml.rb
@@ -6,12 +6,12 @@ module FrontMatterParser
   module Loader
     # {Loader} that uses YAML library
     class Yaml
-      # @!attribute [r] whitelist_classes
+      # @!attribute [r] allowlist_classes
       # Classes that may be parsed by #call.
-      attr_reader :whitelist_classes
+      attr_reader :allowlist_classes
 
-      def initialize(whitelist_classes: [])
-        @whitelist_classes = whitelist_classes
+      def initialize(allowlist_classes: [])
+        @allowlist_classes = allowlist_classes
       end
 
       # Loads a hash front matter from a string
@@ -19,7 +19,7 @@ module FrontMatterParser
       # @param string [String] front matter string representation
       # @return [Hash] front matter hash representation
       def call(string)
-        YAML.safe_load(string, whitelist_classes)
+        YAML.safe_load(string, allowlist_classes)
       end
     end
   end

--- a/spec/front_matter_parser/loader/yaml_spec.rb
+++ b/spec/front_matter_parser/loader/yaml_spec.rb
@@ -12,9 +12,9 @@ describe FrontMatterParser::Loader::Yaml do
       )
     end
 
-    it 'loads with whitelisted classes' do
+    it 'loads with classes in allowlist' do
       string = 'timestamp: 2017-10-17 00:00:00Z'
-      params = { whitelist_classes: [Time] }
+      params = { allowlist_classes: [Time] }
 
       expect(described_class.new(params).call(string)).to eq(
         'timestamp' => Time.parse('2017-10-17 00:00:00Z')


### PR DESCRIPTION
I was using this gem on a project recently and the `whitelist` term was flagged as being a non-inclusive term, this PR renames the `whitelist_classes` param to `allowlist_classes`.

I'd be open to feedback of a better way to depreciate gradually, rather than a straight rename, as this would also prevent the Major version bump.