### PR TITLE
Fixes YAML.safe_load method use.

### DIFF
--- a/lib/front_matter_parser/loader/yaml.rb
+++ b/lib/front_matter_parser/loader/yaml.rb
@@ -19,7 +19,7 @@ module FrontMatterParser
       # @param string [String] front matter string representation
       # @return [Hash] front matter hash representation
       def call(string)
-        YAML.safe_load(string, allowlist_classes)
+        YAML.safe_load(string, permitted_classes: allowlist_classes)
       end
     end
   end


### PR DESCRIPTION
The existing from doesn't work correctly on my Ruby 27.3 install

https://ruby-doc.org/stdlib-3.0.0/libdoc/psych/rdoc/Psych.html#method-c-safe_load