### PR TITLE
Ruby 2.5 compatibility

### DIFF
--- a/lib/front_matter_parser/loader/yaml.rb
+++ b/lib/front_matter_parser/loader/yaml.rb
@@ -19,7 +19,20 @@ module FrontMatterParser
       # @param string [String] front matter string representation
       # @return [Hash] front matter hash representation
       def call(string)
-        YAML.safe_load(string, permitted_classes: allowlist_classes)
+        if safe_load_with_permitted_classes_arg?
+          YAML.safe_load(string, permitted_classes: allowlist_classes)
+        else
+          YAML.safe_load(string, allowlist_classes)
+        end
+      end
+
+      def safe_load_with_permitted_classes_arg?
+        # This `permitted_classes` keyword argument was
+        # introduced in Ruby 2.6, and therefore is not
+        # compatible with Ruby 2.5 and earlier.
+        YAML
+          .public_method(:safe_load).parameters
+          .any? { |type, name| type == :key && name == :permitted_classes }
       end
     end
   end


### PR DESCRIPTION
The recent change at https://github.com/waiting-for-dev/front_matter_parser/pull/11 unfortunately broke this library for Ruby 2.5 and prior. We had some momentary CI issues over at Administrate (eg: https://github.com/thoughtbot/administrate/pull/2023) due to this, showing the following error:

```
Failure/Error: YAML.safe_load(string, permitted_classes: allowlist_classes)

ArgumentError:
  unknown keyword: permitted_classes
# ./lib/front_matter_parser/loader/yaml.rb:22:in `call'
# ./lib/front_matter_parser/parser.rb:67:in `call'
```

Having said that... Ruby 2.5 is now End-of-Life, so perhaps you don't wish to support it any more and prefer to close this PR.

But! :-) although we at Administrate may drop Ruby 2.5 soon, we haven't done it just yet. Other libraries that may depend on this gem may be in a similar situation, so perhaps this you'd consider this change as a stopgap measure while everyone adapts.

Either decision would probably be correct!