### PR TITLE
Make EOF line break optional for multi_line_comment

### DIFF
--- a/lib/front_matter_parser/syntax_parser/multi_line_comment.rb
+++ b/lib/front_matter_parser/syntax_parser/multi_line_comment.rb
@@ -39,7 +39,7 @@ module FrontMatterParser
         ---
         [[:space:]]*
         #{end_delimiter}
-        [[:blank:]]*$[\n\r]
+        [[:blank:]]*$[\n\r]?
         (?<content>.*)
         \z
         /mx

--- a/spec/front_matter_parser/syntax_parser/multi_line_comment_spec.rb
+++ b/spec/front_matter_parser/syntax_parser/multi_line_comment_spec.rb
@@ -259,6 +259,42 @@ describe FrontMatterParser::SyntaxParser::MultiLineComment do
     end
   end
 
+  context 'with front matter and no content' do
+    let(:syntax) { :md }
+
+    context 'and with EOF line break' do
+      let(:string) do
+        <<~STRING
+          ---
+          title: hello
+          ---
+        STRING
+      end
+
+      it 'does not recognize front matter as content' do
+        front_matter = { 'title' => 'hello' }
+
+        expect(parsed).to be_parsed_result_with(front_matter, "")
+      end
+    end
+
+    context 'and without EOF line break' do
+      let(:string) do
+      <<~STRING.chomp
+          ---
+          title: hello
+          ---
+        STRING
+      end
+
+      it 'does not recognize front matter as content' do
+        front_matter = { 'title' => 'hello' }
+
+        expect(parsed).to be_parsed_result_with(front_matter, "")
+      end
+    end
+  end
+
   it 'returns nil if no front matter is found' do
     string = 'Content'
 


### PR DESCRIPTION
This fixes an issue where a file with no content and no EOF line break ended up being parsed with the front matter recognized as content